### PR TITLE
Fix unistd namespace collision by prefixing names

### DIFF
--- a/src/core/include/peacemakr/crypto.h
+++ b/src/core/include/peacemakr/crypto.h
@@ -66,10 +66,10 @@ peacemakr_key_t *PeacemakrKey_new_bytes(crypto_config_t cfg,
                                         const uint8_t *buf);
 void PeacemakrKey_free(peacemakr_key_t *key);
 
-ciphertext_blob_t *encrypt(crypto_config_t cfg, const peacemakr_key_t *key,
+ciphertext_blob_t *peacemakr_encrypt(crypto_config_t cfg, const peacemakr_key_t *key,
                            const plaintext_t *plain, random_device_t *rand);
 
-bool decrypt(const peacemakr_key_t *key, const ciphertext_blob_t *cipher,
+bool peacemakr_decrypt(const peacemakr_key_t *key, const ciphertext_blob_t *cipher,
              plaintext_t *plain);
 
 // base64 encoded

--- a/src/core/src/Encrypt.c
+++ b/src/core/src/Encrypt.c
@@ -543,7 +543,7 @@ static bool asymmetric_decrypt(const peacemakr_key_t *peacemakrkey,
   return true;
 }
 
-ciphertext_blob_t *encrypt(crypto_config_t cfg, const peacemakr_key_t *key,
+ciphertext_blob_t *peacemakr_encrypt(crypto_config_t cfg, const peacemakr_key_t *key,
                            const plaintext_t *plain, random_device_t *rand) {
 
   const EVP_CIPHER *cipher = parse_cipher(cfg.symm_cipher);
@@ -591,7 +591,7 @@ ciphertext_blob_t *encrypt(crypto_config_t cfg, const peacemakr_key_t *key,
   return out;
 }
 
-bool decrypt(const peacemakr_key_t *key, const ciphertext_blob_t *cipher,
+bool peacemakr_decrypt(const peacemakr_key_t *key, const ciphertext_blob_t *cipher,
              plaintext_t *plain) {
   bool success = false;
   buffer_t *plaintext = NULL, *aad = NULL;

--- a/src/core/test/encrypt_asymmetric.c
+++ b/src/core/test/encrypt_asymmetric.c
@@ -41,10 +41,10 @@ void test_asymmetric_algo(symmetric_cipher symm_cipher, asymmetric_cipher cipher
 
   peacemakr_key_t *key = PeacemakrKey_new(cfg, &rand);
 
-  ciphertext_blob_t *ciphertext = encrypt(cfg, key, &plaintext_in, &rand);
+  ciphertext_blob_t *ciphertext = peacemakr_encrypt(cfg, key, &plaintext_in, &rand);
   assert(ciphertext != NULL);
 
-  bool success = decrypt(key, ciphertext, &plaintext_out);
+  bool success = peacemakr_decrypt(key, ciphertext, &plaintext_out);
 
   assert(success);
 

--- a/src/core/test/encrypt_symmetric.c
+++ b/src/core/test/encrypt_symmetric.c
@@ -40,10 +40,10 @@ void test_symmetric_algo(symmetric_cipher cipher) {
 
   peacemakr_key_t *key = PeacemakrKey_new(cfg, &rand);
 
-  ciphertext_blob_t *ciphertext = encrypt(cfg, key, &plaintext_in, &rand);
+  ciphertext_blob_t *ciphertext = peacemakr_encrypt(cfg, key, &plaintext_in, &rand);
   assert(ciphertext != NULL);
 
-  bool success = decrypt(key, ciphertext, &plaintext_out);
+  bool success = peacemakr_decrypt(key, ciphertext, &plaintext_out);
 
   assert(success);
 

--- a/src/core/test/serialize.c
+++ b/src/core/test/serialize.c
@@ -41,7 +41,7 @@ void test_serialize(symmetric_cipher symm_cipher, asymmetric_cipher cipher) {
 
   peacemakr_key_t *key = PeacemakrKey_new(cfg, &rand);
 
-  ciphertext_blob_t *ciphertext = encrypt(cfg, key, &plaintext_in, &rand);
+  ciphertext_blob_t *ciphertext = peacemakr_encrypt(cfg, key, &plaintext_in, &rand);
   assert(ciphertext != NULL);
 
   size_t out_size = 0;
@@ -49,7 +49,7 @@ void test_serialize(symmetric_cipher symm_cipher, asymmetric_cipher cipher) {
   assert(serialized != NULL);
 
   const ciphertext_blob_t *deserialized = deserialize_blob(serialized, out_size);
-  bool success = decrypt(key, deserialized, &plaintext_out);
+  bool success = peacemakr_decrypt(key, deserialized, &plaintext_out);
 
   assert(success);
 


### PR DESCRIPTION
All the others depend on this in that I'll have to change all the calls