### PR TITLE
Break apart dependencies + builder images (big), from release + runti…

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ From the repository base directory,
 
 ---
 
+## Build Dependencies - Golang
+`docker build -t corecrypto-dependencies:latest . -f docker/go-dependencies.Dockerfile --build-arg="CMAKE_BUILD_TYPE=RELEASE"`
+
 ## Build - Golang
 `docker build -t corecrypto:latest . -f docker/go.Dockerfile`
 ## Build (release) - Golang

--- a/bin/release-golang.sh
+++ b/bin/release-golang.sh
@@ -30,5 +30,6 @@ if [[ "${2}" == "release" ]]; then
     BUILD_ARG="CMAKE_BUILD_TYPE=RELEASE"
 fi
 
+docker build -t corecrypto-dependencies:latest . -f docker/go-dependencies.Dockerfile --build-arg=${BUILD_ARG}
 docker build -t corecrypto:latest . -f docker/go.Dockerfile --build-arg=${BUILD_ARG}
 get_crypto_file ${1}

--- a/docker/go-dependencies.Dockerfile
+++ b/docker/go-dependencies.Dockerfile
@@ -1,0 +1,33 @@
+FROM golang:alpine3.8 as builder
+
+RUN apk add --no-cache libbsd-dev git alpine-sdk perl cmake linux-headers
+
+WORKDIR /opt
+RUN git clone -b OpenSSL_1_1_1-stable --single-branch https://github.com/openssl/openssl.git
+
+RUN cd openssl \
+    && ./config --prefix=/usr --openssldir=/etc/ssl --libdir=lib no-async \
+    && make test MANSUFFIX=ssl install
+
+WORKDIR /opt
+
+ADD CMakeLists.txt /opt/CMakeLists.txt
+ADD src/core /opt/src/core
+ADD src/ffi/go /opt/src/ffi/go
+ADD src/ffi/CMakeLists.txt /opt/src/ffi/CMakeLists.txt
+ADD cmake /opt/cmake
+
+ENV GOPATH=/go
+
+ARG CMAKE_BUILD_TYPE=DEBUG
+RUN mkdir -p build && cd build && cmake .. -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DPEACEMAKR_BUILD_GO=ON -DPEACEMAKR_BUILD_IOS=OFF && make check install
+
+ENV GOPATH=/go
+ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+
+RUN apk add --no-cache gcc musl-dev libbsd-dev
+RUN cp -r /opt/src/ffi/go/src /go
+WORKDIR /go/src
+
+RUN go test -v peacemakr/crypto
+

--- a/docker/go.Dockerfile
+++ b/docker/go.Dockerfile
@@ -6,38 +6,7 @@
 # Full license at peacemakr-core-crypto/LICENSE.txt
 #
 
-FROM golang:alpine3.8 as builder
-
-RUN apk add --no-cache libbsd-dev git alpine-sdk perl cmake linux-headers
-
-WORKDIR /opt
-RUN git clone -b OpenSSL_1_1_1-stable --single-branch https://github.com/openssl/openssl.git
-
-RUN cd openssl \
-    && ./config --prefix=/usr --openssldir=/etc/ssl --libdir=lib no-async \
-    && make test MANSUFFIX=ssl install
-
-WORKDIR /opt
-
-ADD CMakeLists.txt /opt/CMakeLists.txt
-ADD src/core /opt/src/core
-ADD src/ffi/go /opt/src/ffi/go
-ADD src/ffi/CMakeLists.txt /opt/src/ffi/CMakeLists.txt
-ADD cmake /opt/cmake
-
-ENV GOPATH=/go
-
-ARG CMAKE_BUILD_TYPE=DEBUG
-RUN mkdir -p build && cd build && cmake .. -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DPEACEMAKR_BUILD_GO=ON -DPEACEMAKR_BUILD_IOS=OFF && make check install
-
-ENV GOPATH=/go
-ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-
-RUN apk add --no-cache gcc musl-dev libbsd-dev
-RUN cp -r /opt/src/ffi/go/src /go
-WORKDIR /go/src
-
-RUN go test -v peacemakr/crypto
+FROM corecrypto-dependencies:latest as builder
 
 FROM alpine:3.8
 


### PR DESCRIPTION
Yea, i fucked up the peacemakr build, so.... with this separation, now downstream builds can reference both corecrypto-dependencies or just corecrypto depending on if it's a build image or a run image