### PR TITLE
Performance improvements

### DIFF
--- a/src/core/src/Buffer.c
+++ b/src/core/src/Buffer.c
@@ -62,6 +62,7 @@ buffer_t *Buffer_new(size_t size) {
   }
 
   buffer_t *ret = malloc(sizeof(buffer_t));
+  EXPECT_NOT_NULL_RET(ret, "Malloc failed!\n");
 
   ret->m_size_bytes_ = size;
 

--- a/src/core/src/CiphertextBlob.c
+++ b/src/core/src/CiphertextBlob.c
@@ -41,6 +41,7 @@ ciphertext_blob_t *CiphertextBlob_new(crypto_config_t cfg, size_t iv_len,
                                       size_t ciphertext_len,
                                       size_t signature_len) {
   ciphertext_blob_t *out = malloc(sizeof(ciphertext_blob_t));
+  EXPECT_NOT_NULL_RET(out, "malloc returned nullptr\n");
 
   out->m_encrypted_key_ = NULL;
   out->m_iv_ = NULL;
@@ -49,7 +50,6 @@ ciphertext_blob_t *CiphertextBlob_new(crypto_config_t cfg, size_t iv_len,
   out->m_ciphertext_ = NULL;
   out->m_signature_ = NULL;
 
-  EXPECT_NOT_NULL_RET(out, "malloc returned nullptr\n");
   // set constants
   out->m_version_ = PEACEMAKR_CORE_CRYPTO_VERSION;
   out->m_encrypted_key_ = NULL;
@@ -102,6 +102,35 @@ ciphertext_blob_t *CiphertextBlob_new(crypto_config_t cfg, size_t iv_len,
   EXPECT_TRUE_CLEANUP_RET((out->m_signature_ != NULL || signature_len == 0),
                           CiphertextBlob_free(out),
                           "creation of digest buffer failed\n");
+
+  return out;
+}
+
+ciphertext_blob_t *
+CiphertextBlob_from_buffers(crypto_config_t cfg, buffer_t *encrypted_key,
+                            buffer_t *iv, buffer_t *tag, buffer_t *aad,
+                            buffer_t *ciphertext, buffer_t *signature) {
+  ciphertext_blob_t *out = malloc(sizeof(ciphertext_blob_t));
+  EXPECT_NOT_NULL_RET(out, "malloc returned nullptr\n");
+  // set constants
+  out->m_version_ = PEACEMAKR_CORE_CRYPTO_VERSION;
+  out->m_encrypted_key_ = NULL;
+  out->m_encryption_mode_ = cfg.mode;
+  out->m_symm_cipher_ = cfg.symm_cipher;
+  out->m_asymm_cipher_ = cfg.asymm_cipher;
+  out->m_digest_algorithm_ = cfg.digest_algorithm;
+
+  if (Buffer_get_size(encrypted_key) != 0) {
+    out->m_encrypted_key_ = encrypted_key;
+  } else {
+    out->m_encrypted_key_ = NULL;
+  }
+
+  out->m_iv_ = iv;
+  out->m_tag_ = tag;
+  out->m_aad_ = aad;
+  out->m_ciphertext_ = ciphertext;
+  out->m_signature_ = signature;
 
   return out;
 }

--- a/src/core/src/CiphertextBlob.h
+++ b/src/core/src/CiphertextBlob.h
@@ -20,6 +20,11 @@ ciphertext_blob_t *CiphertextBlob_new(crypto_config_t cfg, size_t iv_len,
                                       size_t tag_len, size_t aad_len,
                                       size_t ciphertext_len, size_t digest_len);
 
+ciphertext_blob_t *
+CiphertextBlob_from_buffers(crypto_config_t cfg, buffer_t *encrypted_key,
+                            buffer_t *iv, buffer_t *tag, buffer_t *aad,
+                            buffer_t *ciphertext, buffer_t *signature);
+
 void CiphertextBlob_free(ciphertext_blob_t *ciphertext);
 
 void CiphertextBlob_set_version(ciphertext_blob_t *ciphertext,

--- a/src/core/src/Logging.c
+++ b/src/core/src/Logging.c
@@ -11,10 +11,6 @@
 #include <memory.h>
 #include <openssl/err.h>
 
-#ifndef PEACEMAKR_LOG_LEVEL
-#define PEACEMAKR_LOG_LEVEL 0
-#endif
-
 typedef void (*peacemakr_log_cb)(char *);
 static peacemakr_log_cb log_fn = NULL;
 
@@ -22,12 +18,7 @@ void peacemakr_set_log_callback(peacemakr_log_cb l) { log_fn = l; }
 
 static void log_to_stderr(char *msg) { fprintf(stderr, "%s", msg); }
 
-void log_printf(const char *function_name, int line, level_t level,
-                const char *fmt, ...) {
-
-  if (level < PEACEMAKR_LOG_LEVEL) {
-    return;
-  }
+void log_printf(const char *function_name, int line, const char *fmt, ...) {
 
   if (log_fn == NULL) {
     log_fn = &log_to_stderr;

--- a/src/core/src/Logging.h
+++ b/src/core/src/Logging.h
@@ -9,16 +9,25 @@
 #ifndef PEACEMAKR_CORE_CRYPTO_LOGGING_H
 #define PEACEMAKR_CORE_CRYPTO_LOGGING_H
 
-typedef enum { LOG = 0, ERROR = 1 } level_t;
+#ifndef PEACEMAKR_LOG_LEVEL
+#define PEACEMAKR_LOG_LEVEL 0
+#endif
 
-void log_printf(const char *filename, int line, level_t level, const char *fmt,
-                ...);
+void log_printf(const char *filename, int line, const char *fmt, ...);
 
 void openssl_log(const char *filename, int line);
 
-#define PEACEMAKR_LOG(...) log_printf(__FUNCTION__, __LINE__, LOG, __VA_ARGS__)
+#define PEACEMAKR_LOG(...)                                                     \
+  if (PEACEMAKR_LOG_LEVEL != 0)                                                \
+    ;                                                                          \
+  else                                                                         \
+    log_printf(__FUNCTION__, __LINE__, __VA_ARGS__)
 #define PEACEMAKR_ERROR(...)                                                   \
-  log_printf(__FUNCTION__, __LINE__, ERROR, __VA_ARGS__)
+  if (PEACEMAKR_LOG_LEVEL > 1)                                                 \
+    ;                                                                          \
+  else                                                                         \
+    log_printf(__FUNCTION__, __LINE__, __VA_ARGS__)
+
 #define PEACEMAKR_OPENSSL_LOG openssl_log(__FUNCTION__, __LINE__)
 
 #define EXPECT_NOT_NULL_RET(ptr, ...)                                          \


### PR DESCRIPTION
- In deserialize, allow the ciphertext blob to take ownership of the buffers
- Statically determine log level at compile time and optimize away unnecessary calls
- Move malloc/free calls closer together
- Fuzz the entire encrypt/decrypt flow as well as just deserialize