### PR TITLE
Fix for master failure

### DIFF
--- a/src/core/test/CMakeLists.txt
+++ b/src/core/test/CMakeLists.txt
@@ -9,6 +9,8 @@
 enable_testing()
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} -j4 --schedule-random -V)
 
+set(ALL_C_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/test_helper.h ${ALL_C_SOURCE_FILES} PARENT_SCOPE)
+
 if (UNIX AND NOT APPLE)
     find_package(PkgConfig)
     pkg_check_modules(LIBBSD REQUIRED libbsd)

--- a/src/core/test/test_helper.h
+++ b/src/core/test/test_helper.h
@@ -16,13 +16,18 @@
 #include <stdlib.h>
 #endif
 
+// Don't make assert just swallow everything, actually run the code inside the
+// assert
+#ifdef NDEBUG
+#undef assert
+#define assert(e) e
+#endif // NDEBUG
+
 static inline int fill_rand(unsigned char *buf, size_t num) {
   arc4random_buf(buf, num);
   return 0;
 }
 
-static inline const char *rand_err(int err) {
-  return "";
-}
+static inline const char *rand_err(int err) { return ""; }
 
-#endif //PEACEMAKR_CORE_CRYPTO_HELPER_H
+#endif // PEACEMAKR_CORE_CRYPTO_HELPER_H


### PR DESCRIPTION
When assert is disabled by NDEBUG it actually kills the code on the inside of the assert call... so I redefined the assert macro to not do that as a fix.