### PR TITLE
[FIX] Check Python Install Dir

### DIFF
--- a/src/ffi/python/CMakeLists.txt
+++ b/src/ffi/python/CMakeLists.txt
@@ -19,12 +19,13 @@ add_custom_target(python-test
 
 add_dependencies(check python-test)
 
-if (NOT DEFINED ${PYTHON_INSTALL_DIR})
+if (NOT DEFINED PYTHON_INSTALL_DIR)
     install(TARGETS peacemakr_core_crypto_python
             LIBRARY DESTINATION ${Python_SITEARCH}
             COMPONENT dev
     )
 else()
+    message("Installing in ${PYTHON_INSTALL_DIR}")
     install(TARGETS peacemakr_core_crypto_python
             LIBRARY DESTINATION ${PYTHON_INSTALL_DIR}
             COMPONENT dev


### PR DESCRIPTION
Found this when integrate with Python. Variable should be check without the dollar sign :)  
https://stackoverflow.com/questions/31808634/checking-for-cmake-variables/31808788